### PR TITLE
fix nil io on shutdown/cleanup

### DIFF
--- a/lib/puma/acme/plugin.rb
+++ b/lib/puma/acme/plugin.rb
@@ -114,7 +114,7 @@ module Puma
               @logger.log "* Listening on https://#{identifier.value}:#{uri.port} (puma-acme)"
             end
 
-            launcher.binder.listeners << [str, io]
+            launcher.binder.listeners << [str, io] if io
           end
         end
       end


### PR DESCRIPTION
add_ssl_listener fans out to all loopback addresses and returns nil for localhost, so we need to guard for that case
